### PR TITLE
Update CLI.md

### DIFF
--- a/docs/admin/CLI.md
+++ b/docs/admin/CLI.md
@@ -156,7 +156,7 @@ get_site_id example.com
 ```
 
 ## Scripts
-All ApisCP scripts are available under `{{ $themeConfig.APNSCP_ROOT }}/bin/php/scripts`. All scripts make use of the apnscp CLI framework and require invocation with `apnscp_php` to operate.
+All ApisCP scripts are available under `{{ $themeConfig.APNSCP_ROOT }}/bin/scripts`. All scripts make use of the apnscp CLI framework and require invocation with `apnscp_php` to operate.
 
 ### change_dns.php
 


### PR DESCRIPTION
The documentation stated the scripts are under /usr/local/apnscp/bin/php/scripts -- I received a message that this directory doesn't exist. However, then found it at /usr/local/apnscp/bin/scripts