### PR TITLE
Fix screenshot command in WebApps.md

### DIFF
--- a/docs/admin/WebApps.md
+++ b/docs/admin/WebApps.md
@@ -176,10 +176,10 @@ ApisCP ships with a chromium driver for screenshot acquisition of all hosted web
 ```bash
 cpcmd scope:set cp.screenshots true
 # Wait until Bootstrapper finishes reconfiguring server ...
-cpcmd web:capture-inventory
+cpcmd web:inventory-capture
 ```
 
-chromium runs when screenshot updates are required. Setting a large TTL in *[screenshots]* => *ttl* allows these screenshots to remain cached for long periods of time until `web:capture-inventory()` is run.
+chromium runs when screenshot updates are required. Setting a large TTL in *[screenshots]* => *ttl* allows these screenshots to remain cached for long periods of time until `web:inventory-capture()` is run.
 
 ## Ad hoc apps
 


### PR DESCRIPTION
`cpcmd web:capture-inventory` should be `cpcmd web:inventory-capture`:

```[root@cp ~]# cpcmd web:capture-inventory
ERROR  : apnscpFunctionInterceptor::check_permissions(): command `web_capture_inventory' does not exist. Did you mean `web_inventory_capture'?
         0. Error_Reporter::add_error("command `%(target)s' does not exist. Did you mean `%(suggest)s'?", [[target:"web_capture_inventory", suggest:"web_inventory_capture"]])
            [/usr/local/apnscp/lib/log_wrapper.php:72]
         1. error("command `%(target)s' does not exist. Did you mean `%(suggest)s'?", [target:"web_capture_inventory", suggest:"web_inventory_capture"])
            [/usr/local/apnscp/lib/apnscpfunction.php:1025]
         2. apnscpFunctionInterceptor->check_permissions("web", "capture_inventory")
            [/usr/local/apnscp/lib/apnscpfunction.php:946]
         3. apnscpFunctionInterceptor->call("web_capture_inventory", )
            [/usr/local/apnscp/lib/CLI/cmd.php:55]
         4. CLI\__call("web_capture_inventory", )
            [/usr/local/apnscp/lib/CLI/cmd.php:574]
         5. CLI\main()
            [/usr/local/apnscp/bin/cmd:7]
----------------------------------------
MESSAGE SUMMARY
Reporter level: ERROR
ERROR: apnscpFunctionInterceptor::check_permissions(): command `web_capture_inventory' does not exist. Did you mean `web_inventory_capture'?
----------------------------------------

ERROR: apnscpFunctionInterceptor::check_permissions(): command `web_capture_inventory' does not exist. Did you mean `web_inventory_capture'?```